### PR TITLE
Agregar tipos en la funcion fibonacci

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-module.exports = function fibonacci(n) {
+module.exports = function fibonacci(n :number) :number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
En el archivo src/fib.ts

Se especificaron los tipos de los parametros de la funcion fibonacci como number
Se especifico el tipo de retorno de la funcion fibonacci como number

Para probar los cambios, primero se observo en la corrida de eslint que los errores estaban causados por hacer operaciones y retornos de tipo "any", lo cual es causado por no especificar el tipo de los parametros y de retorno de la funcion. Por lo que se corrigio especificando el tipo "number". Luego de esto, se hicieron varias corridas a la funcion, con los siguientes resultados

console.log(fibonacci(0)):   -> retorna 0
console.log(fibonacci(3));   -> retorna 2
console.log(fibonacci(7));   -> retorna 13
console.log(fibonacci(21)); -> retorna 10946